### PR TITLE
Fix HoYoLAB accounts login

### DIFF
--- a/src/Snap.Hutao/Snap.Hutao/Service/User/UserService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/User/UserService.cs
@@ -127,7 +127,13 @@ internal sealed partial class UserService : IUserService, IUserServiceUnsafe
     public async ValueTask<ValueResult<UserOptionResult, string>> ProcessInputCookieAsync(Cookie cookie, bool isOversea)
     {
         await taskContext.SwitchToBackgroundAsync();
-        string? mid = cookie.GetValueOrDefault(isOversea ? Cookie.STUID : Cookie.MID);
+        string? mid = cookie.GetValueOrDefault(Cookie.MID);
+
+        // legacy token compatibility
+        if (string.IsNullOrEmpty(mid) && isOversea)
+        {
+            mid = cookie.GetValueOrDefault(Cookie.STUID);
+        }
 
         if (string.IsNullOrEmpty(mid))
         {

--- a/src/Snap.Hutao/Snap.Hutao/View/Page/ISupportLoginByWebView.cs
+++ b/src/Snap.Hutao/Snap.Hutao/View/Page/ISupportLoginByWebView.cs
@@ -33,7 +33,7 @@ internal interface ISupportLoginByWebView
     {
         (UserOptionResult result, string nickname) = await serviceProvider
             .GetRequiredService<IUserService>()
-            .ProcessInputCookieAsync(cookie, false)
+            .ProcessInputCookieAsync(cookie, isOversea)
             .ConfigureAwait(false);
 
         serviceProvider.GetRequiredService<INavigationService>().GoBack();

--- a/src/Snap.Hutao/Snap.Hutao/Web/Hoyolab/Cookie.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Web/Hoyolab/Cookie.cs
@@ -132,7 +132,17 @@ internal sealed partial class Cookie
 
     public bool TryGetSToken(bool isOversea, [NotNullWhen(true)] out Cookie? cookie)
     {
-        return isOversea ? TryGetLegacySToken(out cookie) : TryGetSToken(out cookie);
+        if (TryGetSToken(out cookie))
+        {
+            return true;
+        }
+
+        if (isOversea)
+        {
+            return TryGetLegacySToken(out cookie);
+        }
+
+        return false;
     }
 
     public bool TryGetLToken([NotNullWhen(true)] out Cookie? cookie)

--- a/src/Snap.Hutao/Snap.Hutao/Web/Hoyolab/Takumi/Event/BbsSignReward/SignInClientOversea.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Web/Hoyolab/Takumi/Event/BbsSignReward/SignInClientOversea.cs
@@ -57,7 +57,7 @@ internal sealed partial class SignInClientOversea : ISignInClient
         HttpRequestMessageBuilder builder = httpRequestMessageBuilderFactory.Create()
             .SetRequestUri(ApiOsEndpoints.SignInRewardSign)
             .SetUserCookie(userAndUid, CookieType.CookieToken)
-            .PostJson(new SignInData(userAndUid.Uid, false));
+            .PostJson(new SignInData(userAndUid.Uid, true));
 
         Response<SignInResult>? resp = await builder
             .TryCatchSendAsync<Response<SignInResult>>(httpClient, logger, token)
@@ -73,7 +73,7 @@ internal sealed partial class SignInClientOversea : ISignInClient
                     .SetRequestUri(ApiOsEndpoints.SignInRewardSign)
                     .SetUserCookie(userAndUid, CookieType.CookieToken)
                     .SetXrpcChallenge(challenge, validate)
-                    .PostJson(new SignInData(userAndUid.Uid, false));
+                    .PostJson(new SignInData(userAndUid.Uid, true));
 
                 resp = await verifiedBuilder
                     .TryCatchSendAsync<Response<SignInResult>>(httpClient, logger, token)


### PR DESCRIPTION
- Fix hoyolab web login
- Allow adding hoyolab account by v2 stoken using "Input Manually"
- Fix hoyolab daily reward claim

Legacy stoken still works for now. Currently v2 stoken can only be obtained by capturing requests from hoyolab mobile app. 