### PR TITLE
自动化Visual Studio配置

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,15 @@
 
 ### Setup Snap.Hutao Project
 
-1. Download and install [Visual Studio 2022 Community](https://visualstudio.microsoft.com/downloads/)
-2. Open Visual Studio Installer to complete Visual Studio installation
-   - You need to install `.NET desktop development`, `Desktop development with C++` and `Universal Windows Platform development` components
-3. Install `Single-project MSIX Packaging Tools for VS 2022` provided by Microsoft in Visual Studio marketplace
-4. Use git to clone the project `https://github.com/DGP-Studio/Snap.Hutao.git` to your local device 
-5. Switch git branch to `develop`
-6. Open project solution with your Visual Studio and then you are ready to go
+1. Download and install [Visual Studio 2022 Community](https://visualstudio.microsoft.com/downloads/).
+   - No need to select workloads; Visual Studio will handle it automatically.
+   - Close Visual Studio Installer to ensure a smooth installation experience for workloads.
+   - If using Visual Studio 2022 17.9 preview, skip step 5, as automatic extension installation is supported in this version.
+2. Use git to clone the project `https://github.com/DGP-Studio/Snap.Hutao.git` to your local device.
+3. Switch to the`develop` branch using git.
+4. Open the project solution with your Visual Studio. Visual Studio will prompt you to install the necessary workloads, closing and reopening automatically.
+5. (For Visual Studio 2022 17.8) Install the [Single-project MSIX Packaging Tools for VS 2022](https://marketplace.visualstudio.com/items?itemName=ProjectReunion.MicrosoftSingleProjectMSIXPackagingToolsDev17) provided by Microsoft in Visual Studio marketplace.
+6. Open the project solution with your Visual Studio, and you are ready to go.
 
 ### Start Pull Request
 

--- a/src/Snap.Hutao/.vsconfig
+++ b/src/Snap.Hutao/.vsconfig
@@ -1,0 +1,11 @@
+{
+    "version": "1.0",
+    "components": [
+        "Microsoft.VisualStudio.Workload.ManagedDesktop",
+        "Microsoft.VisualStudio.Workload.NativeDesktop",
+        "Microsoft.VisualStudio.Workload.Universal"
+    ],
+    "extensions": [
+        "https://marketplace.visualstudio.com/items?itemName=ProjectReunion.MicrosoftSingleProjectMSIXPackagingToolsDev17"
+    ]
+}

--- a/src/Snap.Hutao/Snap.Hutao.sln
+++ b/src/Snap.Hutao/Snap.Hutao.sln
@@ -8,6 +8,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9A95A964-04B1-477A-BDE7-505525B3CAD8}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		.vsconfig = .vsconfig
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Snap.Hutao.Test", "Snap.Hutao.Test\Snap.Hutao.Test.csproj", "{D691BA9F-904C-4229-87A5-E14F2EFF2F64}"
@@ -87,11 +88,11 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		RESX_AutoApplyExistingTranslations = False
-		RESX_NeutralResourcesLanguage = zh-CN
-		SolutionGuid = {E4449B1C-0E6A-4D19-955E-1CA491656ABA}
-		RESX_SortFileContentOnSave = True
-		RESX_ShowErrorsInErrorList = False
 		RESX_Rules = {"EnabledRules":["StringFormat","WhiteSpaceLead","WhiteSpaceTail","PunctuationLead"]}
+		RESX_ShowErrorsInErrorList = False
+		RESX_SortFileContentOnSave = True
+		SolutionGuid = {E4449B1C-0E6A-4D19-955E-1CA491656ABA}
+		RESX_NeutralResourcesLanguage = zh-CN
+		RESX_AutoApplyExistingTranslations = False
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
现在的贡献过程需要开发者手动安装多个workload。适当的优化可以使得开发者的体验更加流畅。
已经在Visual Studio 2022 Community 17.8和17.9 Preview 2.1测试并通过。构建过程无错误。
现在的issue类型里面没有合适的，所以没有开一个，见谅。