### PR TITLE
实现对材料统计页面中的材料做初步排序。

### DIFF
--- a/src/Snap.Hutao/Snap.Hutao/Extension/EnumerableExtension.List.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Extension/EnumerableExtension.List.cs
@@ -201,10 +201,24 @@ internal static partial class EnumerableExtension
     }
 
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    public static List<TSource> SortBy<TSource, TKey>(this List<TSource> list, Func<TSource, TKey> keySelector, IComparer<TKey> comparer)
+    {
+        list.Sort((left, right) => comparer.Compare(keySelector(left), keySelector(right)));
+        return list;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     public static List<TSource> SortByDescending<TSource, TKey>(this List<TSource> list, Func<TSource, TKey> keySelector)
         where TKey : IComparable
     {
         list.Sort((left, right) => keySelector(right).CompareTo(keySelector(left)));
+        return list;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    public static List<TSource> SortByDescending<TSource, TKey>(this List<TSource> list, Func<TSource, TKey> keySelector, IComparer<TKey> comparer)
+    {
+        list.Sort((left, right) => comparer.Compare(keySelector(right), keySelector(left)));
         return list;
     }
 }

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
@@ -126,10 +126,7 @@ internal sealed partial class CultivationService : ICultivationService
 
         token.ThrowIfCancellationRequested();
 
-        return resultItems
-            .OrderByDescending(i => i.TotalCount)
-            .ThenByDescending(i => i.Count)
-            .ToObservableCollection();
+        return resultItems.SortBy(item => item.Inner.Id, MaterialIdComparer.Shared).ToObservableCollection();
     }
 
     /// <inheritdoc/>

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/MaterialIdComparer.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/MaterialIdComparer.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) DGP Studio. All rights reserved.
+// Licensed under the MIT license.
+
+using Snap.Hutao.Model.Primitive;
+using Snap.Hutao.ViewModel.Cultivation;
+
+namespace Snap.Hutao.Service.Cultivation;
+
+internal sealed class MaterialIdComparer : IComparer<MaterialId>
+{
+    private static readonly Lazy<MaterialIdComparer> LazyShared = new(() => new());
+
+    public static MaterialIdComparer Shared { get => LazyShared.Value; }
+
+    public int Compare(MaterialId x, MaterialId y)
+    {
+        return Transform(x).CompareTo(Transform(y));
+    }
+
+    private static uint Transform(MaterialId value)
+    {
+        return value.Value switch
+        {
+            // 摩拉
+            202U => 0U,
+
+            // 经验
+            104001U => 1U,
+            104002U => 2U,
+            104003U => 3U,
+
+            // 魔矿
+            104011U => 4U,
+            104012U => 5U,
+            104013U => 6U,
+
+            _ => value,
+        };
+    }
+}

--- a/src/Snap.Hutao/Snap.Hutao/Service/Metadata/ContextAbstraction/MetadataServiceContextExtension.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Metadata/ContextAbstraction/MetadataServiceContextExtension.cs
@@ -5,6 +5,7 @@ using Snap.Hutao.Model.Metadata.Avatar;
 using Snap.Hutao.Model.Metadata.Item;
 using Snap.Hutao.Model.Metadata.Weapon;
 using Snap.Hutao.Model.Primitive;
+using Snap.Hutao.Service.Cultivation;
 
 namespace Snap.Hutao.Service.Metadata.ContextAbstraction;
 
@@ -67,7 +68,7 @@ internal static class MetadataServiceContextExtension
 #pragma warning disable SH002
     public static IEnumerable<Material> EnumerateInventoryMaterial(this IMetadataListMaterialSource context)
     {
-        return context.Materials.Where(m => m.IsInventoryItem()).OrderBy(m => m.Id.Value);
+        return context.Materials.Where(m => m.IsInventoryItem()).OrderBy(m => m.Id, MaterialIdComparer.Shared);
     }
 
     public static Avatar GetAvatar(this IMetadataDictionaryIdAvatarSource context, AvatarId id)

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/CultivationViewModel.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/CultivationViewModel.cs
@@ -10,7 +10,6 @@ using Snap.Hutao.Service.Navigation;
 using Snap.Hutao.Service.Notification;
 using Snap.Hutao.View.Dialog;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 
 namespace Snap.Hutao.ViewModel.Cultivation;
 
@@ -185,11 +184,6 @@ internal sealed partial class CultivationViewModel : Abstraction.ViewModel
                 if (statistics is not null)
                 {
                     statistics = this.SortStatistics(statistics);
-                    foreach (var item in statistics)
-                    {
-                        Debug.Print("Name: {0}, Id: {1}, Rank: {2}, Material: {3}, Item: {4}",
-                            item.Inner.Name, item.Inner.Id.Value, item.Inner.RankLevel, item.Inner.MaterialType, item.Inner.ItemType);
-                    }
                 }
             }
             catch (OperationCanceledException)

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/CultivationViewModel.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/CultivationViewModel.cs
@@ -181,10 +181,6 @@ internal sealed partial class CultivationViewModel : Abstraction.ViewModel
             {
                 CultivationMetadataContext context = await metadataService.GetContextAsync<CultivationMetadataContext>().ConfigureAwait(false);
                 statistics = await cultivationService.GetStatisticsCultivateItemCollectionAsync(SelectedProject, context, token).ConfigureAwait(false);
-                if (statistics is not null)
-                {
-                    statistics = this.SortStatistics(statistics);
-                }
             }
             catch (OperationCanceledException)
             {
@@ -193,35 +189,6 @@ internal sealed partial class CultivationViewModel : Abstraction.ViewModel
 
             await taskContext.SwitchToMainThreadAsync();
             StatisticsItems = statistics;
-        }
-    }
-
-    private ObservableCollection<StatisticsCultivateItem> SortStatistics(ObservableCollection<StatisticsCultivateItem> statistics)
-    {
-        return statistics.Order(new StatisticsCaltivateItemComparer()).ToObservableCollection();
-    }
-
-    private class StatisticsCaltivateItemComparer: IComparer<StatisticsCultivateItem>
-    {
-        public int Compare(StatisticsCultivateItem? x, StatisticsCultivateItem? y)
-        {
-            // TODO: 理论上的最优解：先通过观测枢获取所有背包物品，然后根据filter字段依次分类，先按这个类别做排序，然后再按品质等进行排序
-            // 不仅如此，以后想按照材料类型分类的话，这也是必做的。
-
-            // 对null做判定，防止IDE警告
-            if (x is null) { return -1; }
-            if (y is null) { return -1; }
-
-            // 摩拉、矿、经验书全局只出现一次，放在最前面
-            if (x.Inner.Id.Value == 202U) { return -1; } // 摩拉
-            if (y.Inner.Id.Value == 202U) { return 1; }
-            if (x.Inner.Id.Value == 104013U) { return -1; } // 精锻用魔矿
-            if (y.Inner.Id.Value == 104013U) { return 1; }
-            if (x.Inner.Id.Value == 104003U) { return -1; } // 大英雄的经验
-            if (y.Inner.Id.Value == 104003U) { return 1; }
-
-            // 剩下的物品暂时按照id排序，更细致的排序策略以后再说
-            return (int)x.Inner.Id.Value - (int)y.Inner.Id.Value;
         }
     }
 

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/CultivationViewModel.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/CultivationViewModel.cs
@@ -213,12 +213,12 @@ internal sealed partial class CultivationViewModel : Abstraction.ViewModel
             if (y is null) { return -1; }
 
             // 摩拉、矿、经验书全局只出现一次，放在最前面
-            if (x.Inner.Name == "摩拉") { return -1; }
-            if (y.Inner.Name == "摩拉") { return 1; }
-            if (x.Inner.Name == "精锻用魔矿") { return -1; }
-            if (y.Inner.Name == "精锻用魔矿") { return 1; }
-            if (x.Inner.Name == "大英雄的经验") { return -1; }
-            if (y.Inner.Name == "大英雄的经验") { return 1; }
+            if (x.Inner.Id.Value == 202U) { return -1; } // 摩拉
+            if (y.Inner.Id.Value == 202U) { return 1; }
+            if (x.Inner.Id.Value == 104013U) { return -1; } // 精锻用魔矿
+            if (y.Inner.Id.Value == 104013U) { return 1; }
+            if (x.Inner.Id.Value == 104003U) { return -1; } // 大英雄的经验
+            if (y.Inner.Id.Value == 104003U) { return 1; }
 
             // 剩下的物品暂时按照id排序，更细致的排序策略以后再说
             return (int)x.Inner.Id.Value - (int)y.Inner.Id.Value;


### PR DESCRIPTION
更细致的排序、分类功能，需要集成观测枢功能才能进行。#1427

效果图：
![image](https://github.com/DGP-Studio/Snap.Hutao/assets/38455509/793cb503-c12b-4c44-a204-9f3c2758e9bf)

![image](https://github.com/DGP-Studio/Snap.Hutao/assets/38455509/10b3b552-4b30-4d76-9696-aee45067c5e6)

![image](https://github.com/DGP-Studio/Snap.Hutao/assets/38455509/a1b100a2-448b-4e3b-93ca-2d8e67cef493)

