### PR TITLE
Fix duplicate cookie in API requests

### DIFF
--- a/src/Snap.Hutao/Snap.Hutao/Core/DependencyInjection/IocHttpClientConfiguration.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Core/DependencyInjection/IocHttpClientConfiguration.cs
@@ -28,6 +28,7 @@ internal static partial class IocHttpClientConfiguration
                         clientHandler.AllowAutoRedirect = true;
                         clientHandler.UseProxy = true;
                         clientHandler.Proxy = provider.GetRequiredService<DynamicHttpProxy>();
+                        clientHandler.UseCookies = false;
                     });
             })
             .AddHttpClients();


### PR DESCRIPTION
Without this PR, if multiple hoyolab account is configured, first request after account switching to the API endpoint will contains cookies of both the previous account and the current one.