### PR TITLE
prompt user dailynote auto-refresh is not effective while notify icon is disabled

### DIFF
--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
@@ -1994,6 +1994,9 @@
   <data name="ViewPageDailyNoteSettingRefreshHeader" xml:space="preserve">
     <value>刷新</value>
   </data>
+  <data name="ViewPageDailyNoteSettingRefreshNotifyIconDisabledHint" xml:space="preserve">
+    <value>未启用通知区域图标，自动刷新将不会执行</value>
+  </data>
   <data name="ViewPageDailyNoteSlientModeDescription" xml:space="preserve">
     <value>在我游玩原神时不通知我</value>
   </data>

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
@@ -1995,7 +1995,7 @@
     <value>刷新</value>
   </data>
   <data name="ViewPageDailyNoteSettingRefreshNotifyIconDisabledHint" xml:space="preserve">
-    <value>未启用通知区域图标，自动刷新将不会执行</value>
+    <value>未启用通知区域图标，关闭窗口后自动刷新将不会执行</value>
   </data>
   <data name="ViewPageDailyNoteSlientModeDescription" xml:space="preserve">
     <value>在我游玩原神时不通知我</value>

--- a/src/Snap.Hutao/Snap.Hutao/View/Page/DailyNotePage.xaml
+++ b/src/Snap.Hutao/Snap.Hutao/View/Page/DailyNotePage.xaml
@@ -507,6 +507,12 @@
                                     Text="{shcm:ResourceString Name=ViewPageDailyNoteSettingRefreshHeader}"/>
                             </cwcont:HeaderedContentControl.Header>
                             <StackPanel Spacing="{StaticResource SettingsCardSpacing}">
+                                <InfoBar
+                                    Title="{shcm:ResourceString Name=ViewPageDailyNoteSettingRefreshNotifyIconDisabledHint}"
+                                    IsClosable="False"
+                                    IsOpen="True"
+                                    Severity="Warning"
+                                    Visibility="{Binding AppOptions.IsNotifyIconEnabled, Converter={StaticResource BoolToVisibilityRevertConverter}}"/>
                                 <cwcont:SettingsCard
                                     Description="{shcm:ResourceString Name=ViewPageDailyNoteSettingAutoRefreshDescription}"
                                     Header="{shcm:ResourceString Name=ViewPageDailyNoteSettingAutoRefresh}"

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/DailyNote/DailyNoteViewModel.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/DailyNote/DailyNoteViewModel.cs
@@ -6,6 +6,7 @@ using Snap.Hutao.Control.Extension;
 using Snap.Hutao.Core;
 using Snap.Hutao.Factory.ContentDialog;
 using Snap.Hutao.Model.Entity;
+using Snap.Hutao.Service;
 using Snap.Hutao.Service.DailyNote;
 using Snap.Hutao.Service.Metadata;
 using Snap.Hutao.Service.Notification;
@@ -32,11 +33,14 @@ internal sealed partial class DailyNoteViewModel : Abstraction.ViewModel
     private readonly IInfoBarService infoBarService;
     private readonly ITaskContext taskContext;
     private readonly IUserService userService;
+    private readonly AppOptions appOptions;
 
     private ObservableCollection<UserAndUid>? userAndUids;
     private ObservableCollection<DailyNoteEntry>? dailyNoteEntries;
 
     public DailyNoteOptions DailyNoteOptions { get => dailyNoteOptions; }
+
+    public AppOptions AppOptions { get => appOptions; }
 
     public IWebViewerSource VerifyUrlSource { get; } = new DailyNoteWebViewerSource();
 


### PR DESCRIPTION
<!--- Hi, thanks for considering make a PR contribution to Snap Hutao, we appreciate your work. -->
<!--- Before you create this PR, please fill the following form and checklist -->

## Description

Add a infobar to daily note auto refresh setting if user has disabled notify icon

## Related Issue

<!--- If there's an associated issue, please use [GitHub Keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) to link it -->
<!-- e.g. fix #999, resolve #999, close #999 -->

## Checklist

- [X] The target PR branch is `develop` branch
