### PR TITLE
lossy fix refresh inventory

### DIFF
--- a/src/Snap.Hutao/Snap.Hutao/Service/Inventory/MinimalPromotionDelta.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Inventory/MinimalPromotionDelta.cs
@@ -73,8 +73,17 @@ internal sealed partial class MinimalPromotionDelta
                 foreach (ref readonly MaterialId materialId in CollectionsMarshal.AsSpan(item.CultivationItems))
                 {
                     ref Constraint? constraint = ref CollectionsMarshal.GetValueRefOrAddDefault(materialConstraintMap, materialId, out _);
-                    constraint ??= solver.MakeConstraint(1, double.PositiveInfinity, $"{materialId}");
+                    if (constraint is null)
+                    {
+                        constraint = solver.MakeConstraint(double.NegativeInfinity, double.PositiveInfinity, $"{materialId}");
+
+                        Variable penalty = solver.MakeNumVar(0, double.PositiveInfinity, $"penalty_{materialId}");
+                        objective.SetCoefficient(penalty, 1000);
+                        constraint.SetCoefficient(penalty, 1);
+                    }
+
                     constraint.SetCoefficient(itemVariableMap[item], 1);
+                    constraint.SetBounds(3, double.PositiveInfinity);
                 }
             }
 


### PR DESCRIPTION
<!--- Hi, thanks for considering make a PR contribution to Snap Hutao, we appreciate your work. -->
<!--- Before you create this PR, please check our contribution guide (https://hut.ao/en/development/contribute.html) and fill out the following form and checklist -->

## Description

由于 `lack_num` 不再返回负数，现在获取详细准确的背包数据暂时不再可用。之前我们采用最小子集来涵盖所有的背包物品，即每种物品至少出现 1 次。

我们可以尝试要求每种物品至少出现 3 次来涵盖较为全面的背包物品及数量。

相对最小子集来说，这种方法能够满足大部分人的背包刷新需求，但是直接获取所有大于等于三星的武器和所有角色也会相对来说更加合理。

## Related Issue

<!--- If there's an associated issue, please use [GitHub Keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) to link it -->
<!-- e.g. fix #999, resolve #999, close #999 -->
fix #2061

## Checklist

- [X] The target PR branch is `develop` branch
