### PR TITLE
Fix logic on Checking Windows Version

### DIFF
--- a/src/Snap.Hutao/Snap.Hutao/Core/UniversalApiContract.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Core/UniversalApiContract.cs
@@ -8,7 +8,7 @@ namespace Snap.Hutao.Core;
 
 internal static class UniversalApiContract
 {
-    public static LazySlim<bool> IsCurrentWindowsVersionSupported { get; } = new(() => new Version("10", "0", "19045", "5371") > WindowsVersion);
+    public static LazySlim<bool> IsCurrentWindowsVersionSupported { get; } = new(() => new Version("10", "0", "19045", "5371") < WindowsVersion);
 
     public static Version? WindowsVersion
     {


### PR DESCRIPTION
<!--- Hi, thanks for considering make a PR contribution to Snap Hutao, we appreciate your work. -->
<!--- Before you create this PR, please check our contribution guide (https://hut.ao/en/development/contribute.html) and fill out the following form and checklist -->

## Description

Change logic on checking Windows Version

## Related Issue
This is fundamentally wrong when the code requires a lower version 19045.5371. I tested on **Windows 11 24H2 (26100.3915)** and **Windows 10 22H2 (19045.5737)**
![debug](https://github.com/user-attachments/assets/99acd485-b1a1-42d7-9670-574487f50697)


## Checklist

- [x] The target PR branch is `develop` branch
