### PR TITLE
Remove Res Download (.Zip file)

### DIFF
--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/MainView.xaml
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/MainView.xaml
@@ -51,11 +51,11 @@
             x:Name="NavView"
             Margin="0,0,0,0"
             shuxc:NavigationViewHelper.PaneCornerRadius="0"
-            CompactPaneLength="48"
+            CompactPaneLength="45"
             IsBackEnabled="{x:Bind ContentFrame.CanGoBack, Mode=OneWay}"
             IsEnabled="{Binding ElementName=ContentFrame, Path=Content.DataContext.IsInitialized, Mode=OneWay}"
             IsPaneOpen="True"
-            OpenPaneLength="192"
+            OpenPaneLength="205"
             PaneDisplayMode="Left"
             UseLayoutRounding="False">
 

--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/LaunchGamePage.xaml
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/LaunchGamePage.xaml
@@ -697,41 +697,6 @@
                     </StackPanel>
                 </ScrollViewer>
             </PivotItem>
-            <PivotItem Header="{shuxm:ResourceString Name=ViewPageLaunchGameResourceHeader}">
-                <Grid>
-                    <ScrollViewer Visibility="{Binding GamePackage, Converter={StaticResource EmptyObjectToBoolConverter}}">
-                        <StackPanel>
-                            <Border Margin="16,16,16,0" cw:Effects.Shadow="{ThemeResource CompatCardShadow}">
-                                <Border Style="{ThemeResource AcrylicBorderCardStyle}">
-                                    <shuxvs:LaunchGameResourceExpander
-                                        cw:Effects.Shadow="{ThemeResource CompatCardShadow}"
-                                        DataContext="{Binding GamePackage.PreDownload.Major, Mode=OneWay}"
-                                        Header="{shuxm:ResourceString Name=ViewPageLaunchGameResourcePreDownloadHeader}"
-                                        IsEnabled="{Binding FallbackValue=False, Converter={StaticResource EmptyObjectToBoolConverter}}"
-                                        IsExpanded="{Binding FallbackValue=False, Converter={StaticResource EmptyObjectToBoolConverter}, Mode=OneTime}"/>
-                                </Border>
-                            </Border>
-                            <ItemsControl
-                                Margin="0,0,0,0"
-                                ItemTemplate="{StaticResource GameResourceTemplate}"
-                                ItemsSource="{Binding GamePackage.PreDownload.Patches, Mode=OneWay}"/>
-                            <Border Margin="16,16,16,0" cw:Effects.Shadow="{ThemeResource CompatCardShadow}">
-                                <Border Style="{ThemeResource AcrylicBorderCardStyle}">
-                                    <shuxvs:LaunchGameResourceExpander
-                                        cw:Effects.Shadow="{ThemeResource CompatCardShadow}"
-                                        DataContext="{Binding GamePackage.Main.Major, Mode=OneWay}"
-                                        Header="{shuxm:ResourceString Name=ViewPageLaunchGameResourceLatestHeader}"/>
-                                </Border>
-                            </Border>
-                            <ItemsControl
-                                Margin="0,0,0,16"
-                                ItemTemplate="{StaticResource GameResourceTemplate}"
-                                ItemsSource="{Binding GamePackage.Main.Patches, Mode=OneWay}"/>
-                        </StackPanel>
-                    </ScrollViewer>
-                    <shuxc:Loading IsLoading="{Binding GamePackage, Converter={StaticResource EmptyObjectToBoolRevertConverter}}" Style="{ThemeResource DefaultLoadingViewStyle}"/>
-                </Grid>
-            </PivotItem>
         </Pivot>
     </shuxc:StandardView>
 </shuxc:ScopedPage>


### PR DESCRIPTION
<!--- Hi, thanks for considering make a PR contribution to Snap Hutao, we appreciate your work. -->
<!--- Before you create this PR, please check our contribution guide (https://hut.ao/en/development/contribute.html) and fill out the following form and checklist -->

## Description

Remove Resource Download and minor change on Navigation bar

## Related Issue
Because in 5.6, HoyoPlay no longer provides the game as a .zip file in Game Package API. So the Resource Download tab will basically be useless anymore. 

And I've tweaked the look and feel of the Navbar a bit to avoid unnecessary text loss in English.

For other languages, especially Vietnamese where there are many words and sentences to translate with very long words, this setup may not be suitable. Hope you can research further. I will try to translate so as to avoid this overflow happening on the project's Crowdin.
**Example**:
![image](https://github.com/user-attachments/assets/d66c6278-944c-4984-9c13-6af3c5a3c13a)


You can see in two Image:

**Before:**

![Before](https://github.com/user-attachments/assets/fe4e7272-8c53-46f7-9093-5fa0893e85a7)

**And After**
![After](https://github.com/user-attachments/assets/0882da29-48d4-4b86-aaba-29c0f5077590)



## Checklist

- [x] The target PR branch is `develop` branch
