### PR TITLE
Swallow the NotSupportedException from Hoyolab clients

### DIFF
--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Home/AnnouncementViewModel.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Home/AnnouncementViewModel.cs
@@ -102,7 +102,18 @@ internal sealed partial class AnnouncementViewModel : Abstraction.ViewModel
                 .GetRequiredService<IOverseaSupportFactory<IHomeClient>>()
                 .CreateFor(userAndUid);
 
-            Response<NewHomeNewInfo>? newHomeInfoResponse = await homeClient.GetNewHomeInfoAsync(2, token).ConfigureAwait(false);
+            Response<NewHomeNewInfo>? newHomeInfoResponse = null;
+
+            // Log the NotSupportedException only. Do not exit.
+            try
+            {
+                newHomeInfoResponse = await homeClient.GetNewHomeInfoAsync(2, token).ConfigureAwait(false);
+            }
+            catch (NotSupportedException)
+            {
+                SentrySdk.AddBreadcrumb(BreadcrumbFactory.CreateDebug("GetNewHomeInfoAsync is unsupported", "AnnouncementViewModel.Command"));
+                return;
+            }
 
             if (!ResponseValidator.TryValidateWithoutUINotification(newHomeInfoResponse, out NewHomeNewInfo? newHomeInfo))
             {
@@ -137,7 +148,18 @@ internal sealed partial class AnnouncementViewModel : Abstraction.ViewModel
                 .GetRequiredService<IOverseaSupportFactory<IMiyoliveClient>>()
                 .CreateFor(userAndUid);
 
-            Response<CodeListWrapper> codeListResponse = await miyoliveClient.RefreshCodeAsync(actId, token).ConfigureAwait(false);
+            Response<CodeListWrapper>? codeListResponse = null;
+
+            // Log the NotSupportedException only. Do not exit.
+            try
+            {
+                codeListResponse = await miyoliveClient.RefreshCodeAsync(actId, token).ConfigureAwait(false);
+            }
+            catch (NotSupportedException)
+            {
+                SentrySdk.AddBreadcrumb(BreadcrumbFactory.CreateDebug("RefreshCodeAsync is unsupported", "AnnouncementViewModel.Command"));
+                return;
+            }
 
             if (!ResponseValidator.TryValidateWithoutUINotification(codeListResponse, out CodeListWrapper? wrapper))
             {

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Home/AnnouncementViewModel.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Home/AnnouncementViewModel.cs
@@ -111,7 +111,7 @@ internal sealed partial class AnnouncementViewModel : Abstraction.ViewModel
             }
             catch (NotSupportedException)
             {
-                SentrySdk.AddBreadcrumb(BreadcrumbFactory.CreateDebug("GetNewHomeInfoAsync is unsupported", "AnnouncementViewModel.Command"));
+                SentrySdk.AddBreadcrumb(BreadcrumbFactory.CreateDebug("GetNewHomeInfoAsync is unsupported", "AnnouncementViewModel.InitializeMiyoliveCodeAsync"));
                 return;
             }
 
@@ -157,7 +157,7 @@ internal sealed partial class AnnouncementViewModel : Abstraction.ViewModel
             }
             catch (NotSupportedException)
             {
-                SentrySdk.AddBreadcrumb(BreadcrumbFactory.CreateDebug("RefreshCodeAsync is unsupported", "AnnouncementViewModel.Command"));
+                SentrySdk.AddBreadcrumb(BreadcrumbFactory.CreateDebug("RefreshCodeAsync is unsupported", "AnnouncementViewModel.InitializeMiyoliveCodeAsync"));
                 return;
             }
 

--- a/src/Snap.Hutao/Snap.Hutao/Web/Hoyolab/Bbs/Home/HomeClientOversea.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Web/Hoyolab/Bbs/Home/HomeClientOversea.cs
@@ -11,6 +11,7 @@ namespace Snap.Hutao.Web.Hoyolab.Bbs.Home;
 [HttpClient(HttpClientConfiguration.XRpc3)]
 internal sealed partial class HomeClientOversea : IHomeClient
 {
+    // TODO: Implement IHomeClient.GetNewHomeInfoAsync
     public ValueTask<Response<NewHomeNewInfo>> GetNewHomeInfoAsync(int gid, CancellationToken token = default)
     {
         return ValueTask.FromException<Response<NewHomeNewInfo>>(HutaoException.NotSupported());

--- a/src/Snap.Hutao/Snap.Hutao/Web/Hoyolab/Takumi/Event/Miyolive/MiyoliveClientOversea.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Web/Hoyolab/Takumi/Event/Miyolive/MiyoliveClientOversea.cs
@@ -11,6 +11,7 @@ namespace Snap.Hutao.Web.Hoyolab.Takumi.Event.Miyolive;
 [HttpClient(HttpClientConfiguration.Default)]
 internal sealed partial class MiyoliveClientOversea : IMiyoliveClient
 {
+    // TODO: Implement IMiyoliveClient.RefreshCodeAsync
     public ValueTask<Response<CodeListWrapper>> RefreshCodeAsync(string actId, CancellationToken token = default)
     {
         return ValueTask.FromException<Response<CodeListWrapper>>(HutaoException.NotSupported());


### PR DESCRIPTION
<!--- Hi, thanks for considering make a PR contribution to Snap Hutao, we appreciate your work. -->
<!--- Before you create this PR, please check our contribution guide (https://hut.ao/en/development/contribute.html) and fill out the following form and checklist -->

## Description

The preview redemption code feature introduced in 1.15.5 breaks the application when the user is from Hoyolab.

This is a rough fix. I'm not sure logging should be used in this way.

Please kindly let me know if there is a better way than implementing `HomeClientOversea` and `MiyoliveClientOversea`.

## Related Issue

Fixes #2844 . Possibly also #2838 .

## Checklist

- [X] The target PR branch is `develop` branch
