### PR TITLE
Improve runner selection logic

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -2,8 +2,7 @@ name: Snap Hutao Alpha
 on:
   workflow_dispatch:
   push:
-    branches:
-      - develop
+    branches: [ develop ]
     paths-ignore:
       - '.gitattributes'
       - '.github/**'
@@ -13,8 +12,7 @@ on:
       - 'LICENSE'
       - '**.yml'
   pull_request:
-    branches:
-      - develop
+    branches: [ develop ]
     paths-ignore:
       - '.gitattributes'
       - '.github/**'
@@ -33,20 +31,43 @@ jobs:
     steps:
       - name: Select runner
         id: select_runner
+        shell: bash
+        env:
+          ORG:  ${{ github.repository_owner }}
+          REPO: ${{ github.repository }}
+          TOKEN: ${{ secrets.RUNNER_CHECK_TOKEN }}
+          LABEL: ${{ vars.RUNNER_LABEL || 'sjc1' }}
         run: |
-          runner_id=${{ vars.RUNNER_ID }}
-          runner_status=$(curl -s -X GET \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: Bearer ${{ secrets.RUNNER_CHECK_TOKEN }}" \
-            https://api.github.com/orgs/DGP-Studio/actions/runners/$runner_id \
-            | jq -r '.status')
-          if [ "$runner_status" == "online" ]; then
-            runner=sjc1
-          else
-            runner=windows-latest
-          fi
-          echo "runner=$runner" >> $GITHUB_OUTPUT
+          set -o pipefail
+          FALLBACK="windows-latest"
 
+          get_status_by_label () {
+            local url="$1"
+            local json
+            json=$(curl -fsSL \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $TOKEN" \
+              "$url" 2>/dev/null || true)
+            jq -r --arg label "$LABEL" '
+              (.runners // [])
+              | map(select(any(.labels[]?; .name==$label)))
+              | .[0].status // ""' <<<"$json" 2>/dev/null || echo ""
+          }
+
+          # Check org's runner first and then repo's
+          STATUS="$(get_status_by_label "https://api.github.com/orgs/${ORG}/actions/runners?per_page=100")"
+          if [ -z "$STATUS" ]; then
+            STATUS="$(get_status_by_label "https://api.github.com/repos/${REPO}/actions/runners?per_page=100")"
+          fi
+
+          if [ "$STATUS" = "online" ]; then
+            PICK="$LABEL"
+          else
+            PICK="$FALLBACK"
+          fi
+
+          echo "Selected runner: $PICK (label=$LABEL, status=${STATUS:-unknown})"
+          echo "runner=$PICK" >> "$GITHUB_OUTPUT"
   build:
     needs: select-runner
     runs-on: ${{ needs.select-runner.outputs.runner }}
@@ -55,7 +76,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup .NET (self-hosted)
-        if: needs.select-runner.outputs.runner == 'sjc1'
+        if: ${{ needs.select-runner.outputs.runner == 'sjc1' }}
         shell: pwsh
         run: |
           Write-Host "Running enviornment setup script…"
@@ -111,6 +132,7 @@ jobs:
           echo $summary >> $Env:GITHUB_STEP_SUMMARY
 
       - name: Clean up
+        shell: pwsh
         run: |
           Write-Host "Cleaning up NuGet cache..."
           Remove-Item -Recurse -Force "$env:USERPROFILE\.nuget\packages"


### PR DESCRIPTION
This pull request updates the `.github/workflows/alpha.yml` GitHub Actions workflow to improve runner selection logic and enhance workflow robustness. The most significant change is a more flexible and dynamic method for selecting a self-hosted runner based on label and status, with a fallback to a default runner if necessary. Additional minor improvements include syntax adjustments and explicit shell declarations.

**Runner selection improvements:**

* Replaced the previous static runner selection logic with a dynamic shell script that checks both organization and repository runners for a specific label, falling back to `windows-latest` if no suitable runner is online. The script uses environment variables for configuration and outputs the selected runner.

**Workflow syntax and robustness:**

* Updated the workflow trigger branch lists for `push` and `pull_request` events to use array syntax for consistency and readability. [[1]](diffhunk://#diff-77705eb5ee9cd3186d976656ab5cd8d5177355a6a4f3631c004205b636830473L5-R5) [[2]](diffhunk://#diff-77705eb5ee9cd3186d976656ab5cd8d5177355a6a4f3631c004205b636830473L16-R15)
* Added explicit `shell` declarations to steps using custom scripts to ensure the correct shell is used during execution. [[1]](diffhunk://#diff-77705eb5ee9cd3186d976656ab5cd8d5177355a6a4f3631c004205b636830473R34-R70) [[2]](diffhunk://#diff-77705eb5ee9cd3186d976656ab5cd8d5177355a6a4f3631c004205b636830473R135)
* Fixed the conditional expression in the `.NET (self-hosted)` setup step to use `${{ ... }}` syntax for proper evaluation.