### PR TITLE
feat(home): Bug Stats dashboard card and Feedback integration

### DIFF
--- a/src/Snap.Hutao/Snap.Hutao/Core/Setting/SettingKeys.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Core/Setting/SettingKeys.cs
@@ -80,6 +80,10 @@ internal static class SettingKeys
 
     public const string IsHomeCardSignInPresented = "IsHomeCardSignInPresented";
     public const string HomeCardSignInOrder = "HomeCardSignInOrder";
+
+    // Bug statistics card
+    public const string IsHomeCardBugStatsPresented = "IsHomeCardBugStatsPresented";
+    public const string HomeCardBugStatsOrder = "HomeCardBugStatsOrder";
     #endregion
 
     #region Compact WebView2

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
@@ -1650,6 +1650,21 @@
   <data name="ViewFeedbackHeader" xml:space="preserve">
     <value>反馈中心</value>
   </data>
+  <data name="ViewPageFeedbackBugSectionHeader" xml:space="preserve">
+    <value>当前版本已确认的问题</value>
+  </data>
+  <data name="ViewPageFeedbackBugWaitingForRelease" xml:space="preserve">
+    <value>已修复（等待发布）</value>
+  </data>
+  <data name="ViewPageFeedbackBugUntreated" xml:space="preserve">
+    <value>未处理</value>
+  </data>
+  <data name="ViewPageFeedbackBugHardToFix" xml:space="preserve">
+    <value>难以处理</value>
+  </data>
+  <data name="ViewPageFeedbackReportIssue" xml:space="preserve">
+    <value>汇报问题</value>
+  </data>
   <data name="ViewGachaLogHeader" xml:space="preserve">
     <value>祈愿记录</value>
   </data>
@@ -3309,11 +3324,17 @@
   <data name="ViewPageSettingHomeCardItemSignInHeader" xml:space="preserve">
     <value>签到</value>
   </data>
+  <data name="ViewPageSettingHomeCardItemBugStatsHeader" xml:space="preserve">
+    <value>问题统计</value>
+  </data>
   <data name="ViewPageSettingHomeCardOff" xml:space="preserve">
     <value>隐藏</value>
   </data>
   <data name="ViewPageSettingHomeCardOn" xml:space="preserve">
     <value>显示</value>
+  </data>
+  <data name="ViewCardBugStatsTitle" xml:space="preserve">
+    <value>问题统计</value>
   </data>
   <data name="ViewPageSettingHomeHeader" xml:space="preserve">
     <value>主页</value>

--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Card/BugStatsCard.xaml
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Card/BugStatsCard.xaml
@@ -1,0 +1,90 @@
+<Button
+    x:Class="Snap.Hutao.UI.Xaml.View.Card.BugStatsCard"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:mxi="using:Microsoft.Xaml.Interactivity"
+    xmlns:shuxb="using:Snap.Hutao.UI.Xaml.Behavior"
+    xmlns:shuxc="using:Snap.Hutao.UI.Xaml.Control"
+    xmlns:shuxcc="using:Snap.Hutao.UI.Xaml.Control.Card"
+    xmlns:shuxm="using:Snap.Hutao.UI.Xaml.Markup"
+    xmlns:shvf="using:Snap.Hutao.ViewModel.Feedback"
+    Height="{ThemeResource HomeAdaptiveCardHeight}"
+    Padding="0"
+    HorizontalAlignment="Stretch"
+    VerticalAlignment="Stretch"
+    HorizontalContentAlignment="Stretch"
+    d:DataContext="{d:DesignInstance shvf:BugStatsViewModelSlim}"
+    Background="Transparent"
+    BorderBrush="{x:Null}"
+    BorderThickness="0"
+    Command="{Binding NavigateCommand}"
+    Style="{ThemeResource DefaultButtonStyle}"
+    mc:Ignorable="d">
+
+    <mxi:Interaction.Behaviors>
+        <shuxb:InvokeCommandOnLoadedBehavior Command="{Binding LoadCommand}"/>
+    </mxi:Interaction.Behaviors>
+
+    <Grid>
+        <Grid Visibility="{Binding IsInitialized, Converter={StaticResource BoolToVisibilityConverter}}">
+            <Grid Margin="12" RowSpacing="6">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="auto"/>
+                    <RowDefinition/>
+                </Grid.RowDefinitions>
+
+                <Grid
+                    Grid.Row="0"
+                    Height="48"
+                    Padding="12"
+                    Style="{ThemeResource GridShimmerStyle}">
+                    <StackPanel
+                        VerticalAlignment="Center"
+                        Orientation="Horizontal"
+                        Spacing="12">
+                        <Image
+                            Width="24"
+                            Height="24"
+                            Margin="-4"
+                            Source="ms-appx:///Resource/Navigation/Feedback.png"/>
+
+                        <TextBlock Text="{shuxm:ResourceString Name=ViewCardBugStatsTitle}"/>
+                    </StackPanel>
+                </Grid>
+
+                <Grid Grid.Row="1" ColumnSpacing="6">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition/>
+                        <ColumnDefinition/>
+                        <ColumnDefinition/>
+                    </Grid.ColumnDefinitions>
+
+                    <Border Grid.Column="0" Padding="12" Style="{ThemeResource BorderShimmerStyle}">
+                        <StackPanel VerticalAlignment="Center" Spacing="4">
+                            <TextBlock HorizontalAlignment="Center" Style="{StaticResource CaptionTextBlockStyle}" Text="{shuxm:ResourceString Name=ViewPageFeedbackBugWaitingForRelease}"/>
+                            <TextBlock HorizontalAlignment="Center" Style="{StaticResource TitleTextBlockStyle}" Text="{Binding WaitingForReleaseCount}"/>
+                        </StackPanel>
+                    </Border>
+
+                    <Border Grid.Column="1" Padding="12" Style="{ThemeResource BorderShimmerStyle}">
+                        <StackPanel VerticalAlignment="Center" Spacing="4">
+                            <TextBlock HorizontalAlignment="Center" Style="{StaticResource CaptionTextBlockStyle}" Text="{shuxm:ResourceString Name=ViewPageFeedbackBugUntreated}"/>
+                            <TextBlock HorizontalAlignment="Center" Style="{StaticResource TitleTextBlockStyle}" Text="{Binding UntreatedCount}"/>
+                        </StackPanel>
+                    </Border>
+
+                    <Border Grid.Column="2" Padding="12" Style="{ThemeResource BorderShimmerStyle}">
+                        <StackPanel VerticalAlignment="Center" Spacing="4">
+                            <TextBlock HorizontalAlignment="Center" Style="{StaticResource CaptionTextBlockStyle}" Text="{shuxm:ResourceString Name=ViewPageFeedbackBugHardToFix}"/>
+                            <TextBlock HorizontalAlignment="Center" Style="{StaticResource TitleTextBlockStyle}" Text="{Binding HardToFixCount}"/>
+                        </StackPanel>
+                    </Border>
+                </Grid>
+            </Grid>
+        </Grid>
+
+        <shuxc:Loading IsLoading="{Binding IsInitialized, Converter={StaticResource BoolNegationConverter}}" Style="{ThemeResource DefaultLoadingCardStyle}"/>
+    </Grid>
+</Button>

--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Card/BugStatsCard.xaml.cs
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Card/BugStatsCard.xaml.cs
@@ -1,0 +1,15 @@
+// Copyright (c) DGP Studio. All rights reserved.
+// Licensed under the MIT license.
+
+using Microsoft.UI.Xaml.Controls;
+
+namespace Snap.Hutao.UI.Xaml.View.Card;
+
+internal sealed partial class BugStatsCard : Button
+{
+    public BugStatsCard(IServiceProvider serviceProvider)
+    {
+        InitializeComponent();
+        this.InitializeDataContext<ViewModel.Feedback.BugStatsViewModelSlim>(serviceProvider);
+    }
+}

--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/FeedbackPage.xaml
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/FeedbackPage.xaml
@@ -230,7 +230,9 @@
                         <Grid Padding="16" RowSpacing="8">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="auto"/>
-                                <RowDefinition/>
+                                <!-- Reduce search results area to make room for bug list below -->
+                                <RowDefinition Height="220"/>
+                                <RowDefinition Height="auto"/>
                             </Grid.RowDefinitions>
                             <AutoSuggestBox
                                 Grid.Row="0"
@@ -293,7 +295,56 @@
                                 </ScrollViewer>
                             </shuxc:StandardView>
 
+                            <!-- Confirmed bugs section -->
+                            <StackPanel Grid.Row="2" Spacing="8">
+                                <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" Text="{shuxm:ResourceString Name=ViewPageFeedbackBugSectionHeader}"/>
 
+                                <Grid ColumnSpacing="8">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition/>
+                                        <ColumnDefinition/>
+                                        <ColumnDefinition/>
+                                    </Grid.ColumnDefinitions>
+
+                                    <!-- Waiting for release -->
+                                    <StackPanel Grid.Column="0" Spacing="4">
+                                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{shuxm:ResourceString Name=ViewPageFeedbackBugWaitingForRelease}"/>
+                                        <ItemsControl ItemsSource="{Binding WaitingForRelease}">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <HyperlinkButton Content="{Binding Title}" NavigateUri="{Binding IssueUri}"/>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </StackPanel>
+
+                                    <!-- Untreated -->
+                                    <StackPanel Grid.Column="1" Spacing="4">
+                                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{shuxm:ResourceString Name=ViewPageFeedbackBugUntreated}"/>
+                                        <ItemsControl ItemsSource="{Binding Untreated}">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <HyperlinkButton Content="{Binding Title}" NavigateUri="{Binding IssueUri}"/>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </StackPanel>
+
+                                    <!-- Hard to fix -->
+                                    <StackPanel Grid.Column="2" Spacing="4">
+                                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{shuxm:ResourceString Name=ViewPageFeedbackBugHardToFix}"/>
+                                        <ItemsControl ItemsSource="{Binding HardToFix}">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <HyperlinkButton Content="{Binding Title}" NavigateUri="{Binding IssueUri}"/>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </StackPanel>
+                                </Grid>
+
+                                <Button Content="{shuxm:ResourceString Name=ViewPageFeedbackReportIssue}" Command="{Binding ReportIssueCommand}" HorizontalAlignment="Left"/>
+                            </StackPanel>
                         </Grid>
                     </shuxc:StandardView>
 

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Feedback/BugStatsViewModelSlim.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Feedback/BugStatsViewModelSlim.cs
@@ -1,0 +1,58 @@
+// Copyright (c) DGP Studio. All rights reserved.
+// Licensed under the MIT license.
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using Snap.Hutao.Service.Notification;
+using Snap.Hutao.UI.Xaml.View.Page;
+using Snap.Hutao.Web.Hutao;
+using Snap.Hutao.Web.Hutao.Issue;
+using Snap.Hutao.Web.Response;
+
+namespace Snap.Hutao.ViewModel.Feedback;
+
+[Service(ServiceLifetime.Transient)]
+[ConstructorGenerated(CallBaseConstructor = true)]
+internal sealed partial class BugStatsViewModelSlim : Abstraction.ViewModelSlim<FeedbackPage>
+{
+    private readonly IInfoBarService infoBarService;
+    private readonly ITaskContext taskContext;
+
+    [ObservableProperty]
+    public partial int WaitingForReleaseCount { get; set; }
+
+    [ObservableProperty]
+    public partial int UntreatedCount { get; set; }
+
+    [ObservableProperty]
+    public partial int HardToFixCount { get; set; }
+
+    protected override async Task LoadAsync()
+    {
+        using (IServiceScope scope = ServiceProvider.CreateScope())
+        {
+            HutaoInfrastructureClient hutaoInfrastructureClient = scope.ServiceProvider.GetRequiredService<HutaoInfrastructureClient>();
+
+            try
+            {
+                HutaoResponse<BugIssuePayload>? resp = await hutaoInfrastructureClient.GetBugIssuesAsync().ConfigureAwait(false);
+
+                if (ResponseValidator.TryValidateWithoutUINotification(resp, out BugIssuePayload? payload) && payload is not null)
+                {
+                    await taskContext.SwitchToMainThreadAsync();
+                    WaitingForReleaseCount = payload.Stat?.WaitingForRelease ?? 0;
+                    UntreatedCount = payload.Stat?.Untreated ?? 0;
+                    HardToFixCount = payload.Stat?.HardToFix ?? 0;
+                }
+            }
+            catch (Exception ex)
+            {
+                infoBarService.Error(ex);
+            }
+            finally
+            {
+                // Always end loading state even if we failed to get data
+                IsInitialized = true;
+            }
+        }
+    }
+}

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Feedback/FeedbackViewModel.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Feedback/FeedbackViewModel.cs
@@ -12,6 +12,7 @@ using Snap.Hutao.Service;
 using Snap.Hutao.Service.Notification;
 using Snap.Hutao.Web.Hutao;
 using Snap.Hutao.Web.Hutao.Algolia;
+using Snap.Hutao.Web.Hutao.Issue;
 using Snap.Hutao.Web.Response;
 using System.Runtime.InteropServices;
 using Windows.System;
@@ -41,19 +42,66 @@ internal sealed partial class FeedbackViewModel : Abstraction.ViewModel
 
     public IPInformation? IPInformation { get; private set => SetProperty(ref field, value); }
 
+    public List<BugIssueItem>? WaitingForRelease { get; private set => SetProperty(ref field, value); }
+
+    public List<BugIssueItem>? Untreated { get; private set => SetProperty(ref field, value); }
+
+    public List<BugIssueItem>? HardToFix { get; private set => SetProperty(ref field, value); }
+
     protected override async ValueTask<bool> LoadOverrideAsync(CancellationToken token)
     {
         IPInformation? info;
+        HutaoResponse<BugIssuePayload>? bugResponse;
         using (IServiceScope scope = serviceProvider.CreateScope())
         {
             HutaoInfrastructureClient hutaoInfrastructureClient = scope.ServiceProvider.GetRequiredService<HutaoInfrastructureClient>();
             Response<IPInformation> resp = await hutaoInfrastructureClient.GetIPInformationAsync(token).ConfigureAwait(false);
             ResponseValidator.TryValidate(resp, infoBarService, out info);
+
+            bugResponse = await hutaoInfrastructureClient.GetBugIssuesAsync(token).ConfigureAwait(false);
         }
 
         info ??= IPInformation.Default;
         await taskContext.SwitchToMainThreadAsync();
         IPInformation = info;
+
+        if (ResponseValidator.TryValidate(bugResponse, infoBarService, out BugIssuePayload? bugs))
+        {
+            // Categorize based on label rules
+            List<BugIssueItem> waiting = new();
+            List<BugIssueItem> untreated = new();
+            List<BugIssueItem> hard = new();
+
+            if (bugs is not null)
+            {
+                foreach (BugIssueItem item in bugs.Details)
+                {
+                    bool isHard = item.Labels.Any(l => string.Equals(l, "needs-community-help", StringComparison.OrdinalIgnoreCase) || l.Contains("无法稳定复现", StringComparison.OrdinalIgnoreCase));
+                    if (isHard)
+                    {
+                        hard.Add(item);
+                        continue;
+                    }
+
+                    // No explicit marker for waiting_for_release in details; we use stats to hint but fallback to title heuristics
+                    bool seemsFixed = item.Labels.Any(l => l.Contains("fixed", StringComparison.OrdinalIgnoreCase) || l.Contains("已修复", StringComparison.OrdinalIgnoreCase))
+                        || item.Title.Contains("[Fixed]", StringComparison.OrdinalIgnoreCase) || item.Title.Contains("已修复", StringComparison.OrdinalIgnoreCase);
+
+                    if (seemsFixed)
+                    {
+                        waiting.Add(item);
+                    }
+                    else
+                    {
+                        untreated.Add(item);
+                    }
+                }
+            }
+
+            WaitingForRelease = waiting.Count > 0 ? waiting : null;
+            Untreated = untreated.Count > 0 ? untreated : null;
+            HardToFix = hard.Count > 0 ? hard : null;
+        }
 
         return true;
     }
@@ -136,5 +184,11 @@ internal sealed partial class FeedbackViewModel : Abstraction.ViewModel
             await taskContext.SwitchToMainThreadAsync();
             LoopbackSupport.EnableLoopback();
         }
+    }
+
+    [Command("ReportIssueCommand")]
+    private static async Task ReportIssueAsync()
+    {
+        await Launcher.LaunchUriAsync(new Uri("https://github.com/DGP-Studio/Snap.Hutao/issues/new/choose"));
     }
 }

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Home/AnnouncementViewModel.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Home/AnnouncementViewModel.cs
@@ -219,6 +219,11 @@ internal sealed partial class AnnouncementViewModel : Abstraction.ViewModel
             result.Add(CardReference.Create(new CalendarCard(serviceProvider), SettingKeys.HomeCardCalendarOrder));
         }
 
+        if (LocalSetting.Get(SettingKeys.IsHomeCardBugStatsPresented, true))
+        {
+            result.Add(CardReference.Create(new BugStatsCard(serviceProvider), SettingKeys.HomeCardBugStatsOrder));
+        }
+
         if (LocalSetting.Get(SettingKeys.IsHomeCardSignInPresented, true))
         {
             result.Add(CardReference.Create(new SignInCard(serviceProvider), SettingKeys.HomeCardSignInOrder));

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Setting/SettingHomeViewModel.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Setting/SettingHomeViewModel.cs
@@ -53,6 +53,7 @@ internal sealed partial class SettingHomeViewModel : Abstraction.ViewModel
             new(SH.ViewPageSettingHomeCardItemAchievementHeader, SettingKeys.IsHomeCardAchievementPresented, SettingKeys.HomeCardAchievementOrder),
             new(SH.ViewPageSettingHomeCardItemDailyNoteHeader, SettingKeys.IsHomeCardDailyNotePresented, SettingKeys.HomeCardDailyNoteOrder),
             new(SH.ViewPageSettingHomeCardItemCalendarHeader, SettingKeys.IsHomeCardCalendarPresented, SettingKeys.HomeCardCalendarOrder),
+            new(SH.ViewPageSettingHomeCardItemBugStatsHeader, SettingKeys.IsHomeCardBugStatsPresented, SettingKeys.HomeCardBugStatsOrder),
             new(SH.ViewPageSettingHomeCardItemSignInHeader, SettingKeys.IsHomeCardSignInPresented, SettingKeys.HomeCardSignInOrder),
         ];
 

--- a/src/Snap.Hutao/Snap.Hutao/Web/Endpoint/Hutao/IInfrastructureEndpoints.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Web/Endpoint/Hutao/IInfrastructureEndpoints.cs
@@ -22,4 +22,9 @@ internal interface IInfrastructureEndpoints :
     {
         return $"{Root}/ips";
     }
+
+    public string IssueBug()
+    {
+        return $"{Root}/issue/bug";
+    }
 }

--- a/src/Snap.Hutao/Snap.Hutao/Web/Hutao/HutaoInfrastructureClient.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Web/Hutao/HutaoInfrastructureClient.cs
@@ -4,6 +4,7 @@
 using Snap.Hutao.Core.DependencyInjection.Annotation.HttpClient;
 using Snap.Hutao.Web.Endpoint.Hutao;
 using Snap.Hutao.Web.Hutao.Response;
+using Snap.Hutao.Web.Hutao.Issue;
 using Snap.Hutao.Web.Request.Builder;
 using Snap.Hutao.Web.Request.Builder.Abstraction;
 using Snap.Hutao.Win32;
@@ -67,6 +68,16 @@ internal sealed partial class HutaoInfrastructureClient
             .Get();
 
         HutaoResponse? resp = await builder.SendAsync<HutaoResponse>(httpClient, token).ConfigureAwait(false);
+        return Web.Response.Response.DefaultIfNull(resp);
+    }
+
+    public async ValueTask<HutaoResponse<BugIssuePayload>> GetBugIssuesAsync(CancellationToken token = default)
+    {
+        HttpRequestMessageBuilder builder = httpRequestMessageBuilderFactory.Create()
+            .SetRequestUri(hutaoEndpointsFactory.Create().IssueBug())
+            .Get();
+
+        HutaoResponse<BugIssuePayload>? resp = await builder.SendAsync<HutaoResponse<BugIssuePayload>>(httpClient, token).ConfigureAwait(false);
         return Web.Response.Response.DefaultIfNull(resp);
     }
 }

--- a/src/Snap.Hutao/Snap.Hutao/Web/Hutao/Issue/BugIssueItem.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Web/Hutao/Issue/BugIssueItem.cs
@@ -1,0 +1,28 @@
+// Copyright (c) DGP Studio. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Snap.Hutao.Web.Hutao.Issue;
+
+internal sealed class BugIssueItem
+{
+    [JsonPropertyName("number")]
+    public int Number { get; set; }
+
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = string.Empty;
+
+    [JsonPropertyName("labels")]
+    public List<string> Labels { get; set; } = [];
+
+    [JsonPropertyName("author")]
+    public string Author { get; set; } = string.Empty;
+
+    [JsonPropertyName("created_at")]
+    public DateTimeOffset CreatedAt { get; set; }
+
+    [JsonIgnore]
+    public string Url => $"https://github.com/DGP-Studio/Snap.Hutao/issues/{Number}";
+
+    [JsonIgnore]
+    public Uri IssueUri => new(Url);
+}

--- a/src/Snap.Hutao/Snap.Hutao/Web/Hutao/Issue/BugIssueResponse.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Web/Hutao/Issue/BugIssueResponse.cs
@@ -1,0 +1,25 @@
+// Copyright (c) DGP Studio. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Snap.Hutao.Web.Hutao.Issue;
+
+internal sealed class BugIssueStats
+{
+    [JsonPropertyName("waiting_for_release")]
+    public int WaitingForRelease { get; set; }
+
+    [JsonPropertyName("untreated")]
+    public int Untreated { get; set; }
+
+    [JsonPropertyName("hard_to_fix")]
+    public int HardToFix { get; set; }
+}
+
+internal sealed class BugIssuePayload
+{
+    [JsonPropertyName("details")]
+    public List<BugIssueItem> Details { get; set; } = [];
+
+    [JsonPropertyName("stat")]
+    public BugIssueStats Stat { get; set; } = new();
+}


### PR DESCRIPTION
This PR adds a Bug Stats card to the Home dashboard and integrates with the Feedback Center.\n\nWhat’s included:\n- New BugStatsCard (UI) and BugStatsViewModelSlim\n- Fetch /issue/bug stats via HutaoInfrastructureClient\n- Navigate to Feedback page on click\n- Settings toggle and order in Home settings\n- zh-CN localization for card title and settings\n\nValidation:\n- Static analysis: no new errors reported in modified files.\n- The card uses existing patterns for cards and navigation; CI will perform the authoritative build and packaging checks.\n\nCloses #2973